### PR TITLE
Rewrite environment interface and implement new environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC = g++
 SOURCE = ./src
 OBJDIR = ./obj
-OBJ = weight.o 2048_env.o opt_env.o dnn_agent.o evolution_strategy.o main.o
+OBJ = weight.o 2048_env.o opt_env.o dnn_agent.o evolution_strategy.o fit_env.o main.o
 OBJS = $(addprefix $(OBJDIR)/, $(OBJ))
 
 OPT_DEGREE = -O3
@@ -31,6 +31,8 @@ $(OBJDIR)/weight.o: weight.cpp weight.h
 $(OBJDIR)/2048_env.o: 2048_env.cpp 2048_env.h
 	$(CC) -c $(CFLAGS) $< -o $@
 $(OBJDIR)/opt_env.o: opt_env.cpp opt_env.h abstract_env.h
+	$(CC) -c $(CFLAGS) $< -o $@
+$(OBJDIR)/fit_env.o: fit_env.cpp fit_env.h abstract_env.h
 	$(CC) -c $(CFLAGS) $< -o $@
 $(OBJDIR)/dnn_agent.o: dnn_agent.cpp dnn_agent.h abstract_agent.h
 	$(CC) -c $(CFLAGS) $< -o $@

--- a/src/2048_board.h
+++ b/src/2048_board.h
@@ -23,6 +23,7 @@
 #include <sstream>
 #include <cmath>
 #include <fstream>
+#include "matrix.h"
 
 /**
 * The simplest bitboard implementation for 2048 board
@@ -226,79 +227,18 @@ public:
         return out;
     }
 
+    inline Matrix get_observation() const
+    {
+        Matrix observation = arma::zeros<Matrix>(1,16);
+        for(int i = 0; i < 16; ++i){
+            observation(i) = this->at(i);
+        }
+        return observation;
+    }
+
 private:
     value_t raw;
 };
 
-
-/**
-* afterstate wrapper
-*/
-class state {
-public:
-    state() : opcode(-1), after(0), value(0), reward(-1) {}
-    state(const board& b) : opcode(-1), after(b), value(0), reward(-1) {}
-    state(const int& opcode) : opcode(opcode), after(0), value(0), reward(-1) {}
-    state(const state& st) : opcode(st.opcode), after(st.after), value(st.value), reward(st.reward) {}
-    operator board& () { return after; }
-    operator int& () { return reward; }
-
-    bool operator >(const state& st) const { return value > st.value; }
-    int move(const int opcode) {            // return reward
-        reward = after.move(opcode);
-        return reward;
-    }
-
-    int get_reward() { return reward; }
-
-    // int evaluate_score() {
-    //  value = 0;
-    //  for (size_t i = 0; i < feature::list().size(); i++)
-    //      value += feature::list()[i]->estimate(after);
-    //  return value;
-    // }
-
-    board get_board() { return after; }
-
-    bool is_valid() const {
-        if (std::isnan(value)) {
-            std::cerr << "numeric exception" << std::endl;
-            std::exit(1);
-        }
-        return reward != -1;
-    }
-    const char* name() const {
-        static const char* opname[4] = { "up", "right", "down", "left" };
-        return opname[opcode];
-    }
-
-    friend std::ostream& operator <<(std::ostream& out, const state& st) {
-        out << "moving " << st.name() << ", reward = " << st.reward;
-        if (st.is_valid()) {
-            std::cout << ", value = " << st.value << std::endl << st.after;
-        }
-        else {
-            std::cout << " (invalid)" << std::endl;
-        }
-        return out;
-    }
-
-    void PrintState() {
-        for (int i = 0; i < 16; i++) {
-            printf(" %2d ", after.at(i));
-            if (i % 4 == 3)
-                printf("\n");
-        }
-        printf("\n");
-        getchar();
-    }
-private:
-    int opcode;
-    board after;
-    float value;
-    int reward;
-};
-
-typedef board Board;
-typedef state State;
+typedef board Board2048;
 #endif

--- a/src/2048_env.h
+++ b/src/2048_env.h
@@ -6,6 +6,7 @@
 #include "abstract_env.h"
 #include "2048_board.h"
 
+// Provide the total reward of each 2048 game episode and let the agent figure out the best playing policy.
 class Game2048Env : public AbstractEnv{
 public:
     Game2048Env();

--- a/src/2048_env.h
+++ b/src/2048_env.h
@@ -9,25 +9,7 @@
 class Game2048Env : public AbstractEnv{
 public:
     Game2048Env();
-    ~Game2048Env();
-    double evaluate_agent(AbstractAgent& agent);
-    double evaluate(Matrix input){return 0;}
-    inline Board get_board(){return m_board;}
-
-
-    // copy_env() // constructor
-    inline void reset_env(){m_board.init();}
-    inline uint get_input_size(){return m_input_size;}
-    inline uint get_output_size(){return m_output_size;}
-    Matrix get_observation();
-    void do_action(Matrix action);
-
-
-private:
-    unsigned int m_seed;
-    Board m_board;
-    uint m_input_size;
-    uint m_output_size;
+    double evaluate_agent(const AbstractAgent &agent, bool verbose=false) const override;
 
 };
 

--- a/src/abstract_agent.h
+++ b/src/abstract_agent.h
@@ -10,7 +10,7 @@ public:
     AbstractAgent(){};
     virtual ~AbstractAgent(){};
 
-    virtual Matrix evaluate_action(const Matrix &observation) = 0; // return an action
+    virtual Matrix evaluate_action(const Matrix &observation) const = 0; // return an action
     virtual void add_weights(const Weights &offsets) = 0;
     inline virtual const Weights& get_weights() const { return m_model_weights; }
 

--- a/src/abstract_env.h
+++ b/src/abstract_env.h
@@ -1,18 +1,21 @@
 #ifndef __ABSTRACT_ENV_H__
 #define __ABSTRACT_ENV_H__
 
+#include <cstdint>
 #include "abstract_agent.h"
 
 class AbstractEnv{
     protected:
-        uint problem_size;
+        uint32_t m_input_size;
+        uint32_t m_output_size;
 
     public:
-        AbstractEnv(){};
+        AbstractEnv():m_input_size(0), m_output_size(0) {};
         virtual ~AbstractEnv(){};
-        virtual double evaluate_agent(AbstractAgent &ai) = 0;
-        uint32_t get_input_size() const;
-        uint32_t get_output_size() const;
+        virtual double evaluate_agent(const AbstractAgent &agent, bool verbose=false) const = 0;
+
+        inline uint32_t get_input_size() const { return m_input_size; }
+        inline uint32_t get_output_size() const { return m_output_size; }
 };
 
 #endif

--- a/src/abstract_env.h
+++ b/src/abstract_env.h
@@ -12,6 +12,8 @@ class AbstractEnv{
     public:
         AbstractEnv():m_input_size(0), m_output_size(0) {};
         virtual ~AbstractEnv(){};
+        // AbstractEnv do not contain per-game variables.
+        // Every game is held and maintained during the evaluate_agent() lifetime, so we don't need to copy Env anymore.
         virtual double evaluate_agent(const AbstractAgent &agent, bool verbose=false) const = 0;
 
         inline uint32_t get_input_size() const { return m_input_size; }

--- a/src/dnn_agent.cpp
+++ b/src/dnn_agent.cpp
@@ -13,13 +13,13 @@ DnnAgent::DnnAgent(const DnnAgent& agent) {
 
 DnnAgent::~DnnAgent() {}
 
-Matrix DnnAgent::evaluate_action(const Matrix &observation)
+Matrix DnnAgent::evaluate_action(const Matrix &observation) const
 {
     Matrix result = observation;
     for(int i = 0; i < m_model_weights.get_count()-1; i+=2) {
         result = result*m_model_weights[i] + m_model_weights[i+1];
         if(i != m_model_weights.get_count()-2)
-            result = relu(result);
+            result = DnnAgent::relu(result);
     }
     return result;
 }
@@ -82,7 +82,7 @@ void DnnAgent::load_config_layer_(const std::string &filename,
     }
 }
 
-Matrix DnnAgent::relu(Matrix matrix) {
+Matrix DnnAgent::relu(const Matrix &matrix) {
     Matrix relu_mat = matrix;
     for(int i = 0; i < relu_mat.size(); i++) {
         if(matrix(i) < 0) relu_mat(i) = 0;

--- a/src/dnn_agent.cpp
+++ b/src/dnn_agent.cpp
@@ -17,7 +17,8 @@ Matrix DnnAgent::evaluate_action(const Matrix &observation) const
 {
     Matrix result = observation;
     for(int i = 0; i < m_model_weights.get_count()-1; i+=2) {
-        result = result*m_model_weights[i] + m_model_weights[i+1];
+        result = result*m_model_weights[i];
+        result.each_row() += m_model_weights[i+1];
         if(i != m_model_weights.get_count()-2)
             result = DnnAgent::relu(result);
     }

--- a/src/dnn_agent.h
+++ b/src/dnn_agent.h
@@ -19,12 +19,12 @@ public:
     DnnAgent& operator=(const DnnAgent &);
     virtual void copy_agent(DnnAgent *new_agent);
     void build_model();
-    virtual Matrix evaluate_action(const Matrix &observation);
+    virtual Matrix evaluate_action(const Matrix &observation) const override;
 
     virtual void add_weights(const Weights &offsets);
 
     virtual void dump_config(const std::string &filename) const;
-    Matrix relu(Matrix);
+    static Matrix relu(const Matrix &matrix);
 
 private:
     void load_config_layer_(const std::string &filename, std::vector<int> &layers);

--- a/src/evolution_strategy.cpp
+++ b/src/evolution_strategy.cpp
@@ -1,4 +1,5 @@
 #include "evolution_strategy.h"
+#include "utils.h"
 
 EvolutionStrategy::EvolutionStrategy(uint thread_num, uint pop_num, double param_sigma, double param_alpha){
     m_thread_number = thread_num;
@@ -20,9 +21,7 @@ EvolutionStrategy::~EvolutionStrategy(){
 }
 
 void EvolutionStrategy::write_log(int cur_iteration, double reward_mean){
-    struct timeval stopT;
-    gettimeofday(&stopT, NULL);
-    double end_time = stopT.tv_sec + (1.0/1000000) * stopT.tv_usec;
+    double end_time = utils::get_current_time_in_seconds();
 
     std::cout << "cur_iteration " << cur_iteration << ", time: " << end_time - m_start_time << ", average reward " << reward_mean << std::endl;
     m_csv_log_file = fopen("log.csv", "a+");
@@ -34,9 +33,7 @@ void EvolutionStrategy::train(AbstractEnv & problem, DnnAgent* ai, uint max_iter
 
     vector<Weights> noised_weights;
 
-    struct timeval startT;
-    gettimeofday(&startT, NULL);
-    m_start_time = startT.tv_sec + (1.0/1000000) * startT.tv_usec;
+    m_start_time = utils::get_current_time_in_seconds();
     Matrix normalized_retrun;
     Matrix rewards;
 

--- a/src/fit_env.cpp
+++ b/src/fit_env.cpp
@@ -1,0 +1,17 @@
+#include "fit_env.h"
+
+FitEnv::FitEnv(uint32_t batch_size, uint32_t input_size/*=2*/)
+:m_batch_size(batch_size)
+{
+    m_input_size = input_size;
+    m_output_size = 1;
+}
+
+double FitEnv::evaluate_agent(const AbstractAgent &agent, bool verbose/*=false*/) const
+{
+    Matrix inputs = -5+10*arma::randu<Matrix>(m_batch_size, m_input_size);
+    Matrix answers = FitEnv::get_function_output(inputs);
+    Matrix predictions = agent.evaluate_action(inputs);
+    Matrix diff = arma::abs(answers - predictions);
+    return -arma::accu(diff)/m_batch_size;
+}

--- a/src/fit_env.h
+++ b/src/fit_env.h
@@ -1,0 +1,15 @@
+#ifndef __FIT_ENV_H__
+#define __FIT_ENV_H__
+
+#include "matrix.h"
+#include "abstract_env.h"
+
+class FitEnv : public AbstractEnv{
+    public:
+        explicit FitEnv(uint32_t batch_size, uint32_t input_size=2);
+        double evaluate_agent(const AbstractAgent &agent, bool verbose=false) const override;
+        static inline Matrix get_function_output(const Matrix &input) { return 0.5 * arma::sum(arma::pow(input,4) - 16* arma::pow(input,2) + 5*input, 1); }
+    protected:
+        uint32_t m_batch_size;
+};
+#endif

--- a/src/fit_env.h
+++ b/src/fit_env.h
@@ -4,6 +4,9 @@
 #include "matrix.h"
 #include "abstract_env.h"
 
+// FitEnv has a black box function f(x) and agent represents another function g(x)
+// Sample `batch_size` points and fit these points to f(x) and g(x) respectively.
+// The FitEnv will provide the summation of |f(x) - g(x)| for all samples and the agent has to find out what's the black box function f(x) is.
 class FitEnv : public AbstractEnv{
     public:
         explicit FitEnv(uint32_t batch_size, uint32_t input_size=2);

--- a/src/fit_env.h
+++ b/src/fit_env.h
@@ -3,6 +3,7 @@
 
 #include "matrix.h"
 #include "abstract_env.h"
+#include "math_functions.h"
 
 // FitEnv has a black box function f(x) and agent represents another function g(x)
 // Sample `batch_size` points and fit these points to f(x) and g(x) respectively.
@@ -11,7 +12,7 @@ class FitEnv : public AbstractEnv{
     public:
         explicit FitEnv(uint32_t batch_size, uint32_t input_size=2);
         double evaluate_agent(const AbstractAgent &agent, bool verbose=false) const override;
-        static inline Matrix get_function_output(const Matrix &input) { return 0.5 * arma::sum(arma::pow(input,4) - 16* arma::pow(input,2) + 5*input, 1); }
+        static inline Matrix get_function_output(const Matrix &input) { return function::styblinski_tang(input); }
     protected:
         uint32_t m_batch_size;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,11 +1,11 @@
 #include <iostream>
 #include <vector>
-#include <sys/time.h>
 #include <string>
 #include <omp.h>
 #include "dnn_agent.h"
 #include "matrix.h"
 #include "opt_env.h"
+#include "fit_env.h"
 #include "evolution_strategy.h"
 #include "2048_env.h"
 #include "utils.h"
@@ -67,6 +67,8 @@ int main(int argc, char **argv){
     }
 
     Game2048Env problem = Game2048Env();
+    // FitEnv problem(10, 3);
+    // OptEnv problem(3);
     model.insert(model.begin(), problem.get_input_size());
     model.push_back(problem.get_output_size());
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,12 +8,15 @@
 #include "opt_env.h"
 #include "evolution_strategy.h"
 #include "2048_env.h"
+#include "utils.h"
 
 using std::cout;
 using std::endl;
 using std::string;
 
 int main(int argc, char **argv){
+    utils::init_random_seed();
+
     FILE * config_file;
     config_file = fopen("config.txt", "r");
     if (config_file == NULL){

--- a/src/math_functions.h
+++ b/src/math_functions.h
@@ -1,0 +1,33 @@
+#ifndef __MATH_FUNCTIONS_H__
+#define __MATH_FUNCTIONS_H__
+
+#include "matrix.h"
+
+// Testinf function reference: https://en.wikipedia.org/wiki/Test_functions_for_optimization
+namespace function{
+
+// Styblinski–Tang function
+inline Matrix styblinski_tang(const Matrix &input) {return 0.5 * arma::sum(arma::pow(input,4) - 16* arma::pow(input,2) + 5*input, 1); }
+inline Matrix styblinski_tang_critical_point(int dimension) { return -2.903534*arma::ones<Matrix>(1, dimension); }
+inline double styblinski_tang_minimum(int dimension) { return -39.166165 * dimension; }
+
+// Sphere function
+inline Matrix sphere(const Matrix &input) { return arma::sum(arma::square(input),1); }
+inline Matrix sphere_critical_point(int dimension) { return arma::zeros<Matrix>(1, dimension); }
+inline double sphere_minimum(int dimension) { return 0; }
+
+
+// Rastrigin function
+inline Matrix rastrigin(const Matrix &input) {
+    static const double SCALE = 10;
+    static const double PI = 3.1415926535897;
+
+    Matrix tmp = arma::square(input) - SCALE*arma::cos(2*PI*input);
+    return SCALE*input.n_cols + arma::sum(tmp,1);
+}
+inline Matrix rastrigin_critical_point(int dimension) { return arma::zeros<Matrix>(1, dimension); }
+inline double rastrigin_minimum(int dimension){ return 0; }
+
+}
+
+#endif

--- a/src/opt_env.cpp
+++ b/src/opt_env.cpp
@@ -1,28 +1,17 @@
 #include "opt_env.h"
 
-OptEnv::OptEnv(uint p_size){
-    // OptEnv::problem_weight = randn<mat>(p_size);
-    m_problem_size = p_size;
-
+OptEnv::OptEnv(uint32_t output_size)
+{
+    m_input_size = output_size;
+    m_output_size = output_size;
+    m_dummy_state = arma::zeros<Matrix>(1, m_output_size);
+    m_target_matrix = arma::randu<Matrix>(1, m_output_size);
 }
 
-OptEnv::~OptEnv(){
-
-}
-
-double OptEnv::evaluate(Matrix input_matrix){
-    Matrix value = zeros(1);
-    for(int i = 0; i < input_matrix.size(); i++){
-        value += input_matrix[i]*input_matrix[i];
-    }
-    return value(0);
-    // return input_matrix*OptEnv::problem_weight;
-}
-
-double OptEnv::evaluate_agent(AbstractAgent &ai){
-    Matrix x = randu<Matrix>(1,m_problem_size);
-
-    Matrix diff = ai.evaluate_action(x) - evaluate(x);
-    Matrix loss = diff.t() * diff;
+double OptEnv::evaluate_agent(const AbstractAgent &agent, bool verbose/*=false*/) const
+{
+    Matrix diff = agent.evaluate_action(m_dummy_state) - m_target_matrix;
+    Matrix loss = diff * diff.t();
+    if (verbose) { std::cout << "L2 Norm : " << -loss(0,0) << std::endl; }
     return -loss(0,0);
 }

--- a/src/opt_env.cpp
+++ b/src/opt_env.cpp
@@ -1,17 +1,21 @@
 #include "opt_env.h"
 
 OptEnv::OptEnv(uint32_t output_size)
+:m_dummy_state(arma::zeros<Matrix>(1, output_size))
 {
     m_input_size = output_size;
     m_output_size = output_size;
-    m_dummy_state = arma::zeros<Matrix>(1, m_output_size);
-    m_target_matrix = arma::randu<Matrix>(1, m_output_size);
 }
 
 double OptEnv::evaluate_agent(const AbstractAgent &agent, bool verbose/*=false*/) const
 {
-    Matrix diff = agent.evaluate_action(m_dummy_state) - m_target_matrix;
-    Matrix loss = diff * diff.t();
-    if (verbose) { std::cout << "L2 Norm : " << -loss(0,0) << std::endl; }
-    return -loss(0,0);
+    Matrix x = agent.evaluate_action(m_dummy_state);
+    Matrix prediction = get_function_output(x);
+    if (verbose) {
+        std::cout << "Agent output x : " << x;
+        std::cout << "Optimal x : " << get_critical_point();
+        std::cout << "f(x) : " << prediction(0,0) << std::endl;
+        std::cout << "Minimun f(x): " << get_function_minimum() << std::endl;
+    }
+    return -prediction(0,0);
 }

--- a/src/opt_env.h
+++ b/src/opt_env.h
@@ -5,19 +5,21 @@
 #include "matrix.h"
 #include "abstract_env.h"
 #include "abstract_agent.h"
+#include "math_functions.h"
 
-// The optEnv has a hidden target matrix with shape (1, `problem_size`)
-// The agent guess a matrix and the OptEnv will provide the mean squared error between the guessing and the answer.
-// The agent has to figure out what is the target matrix.
-// OptEnv doesn't nedd an "observation", but we still provide a zero matrix as dummy observation for interface alignment.
+// OptEnv has a black box function f(x) and the agent has to find the correct x that leads to the minimal f(x).
+// For each x output from the agant, optEnv will provide the f(x) as a hint.
+// OptEnv doesn't need an "observation", but we still provide a ones matrix as dummy observation for interface alignment.
 class OptEnv : public AbstractEnv{
     public:
         explicit OptEnv(uint32_t problem_size);
         double evaluate_agent(const AbstractAgent &agent, bool verbose=false) const override;
-        const Matrix& get_target_matrix() const { return m_target_matrix; }
+        static inline Matrix get_function_output(const Matrix &input) { return function::rastrigin(input); }
+        inline Matrix get_critical_point() const { return function::rastrigin_critical_point(m_input_size); }
+        inline double get_function_minimum() const { return function::rastrigin_minimum(m_input_size); }
+
     protected:
-        Matrix m_dummy_state;
-        Matrix m_target_matrix;
+        const Matrix m_dummy_state;
 };
 
 #endif

--- a/src/opt_env.h
+++ b/src/opt_env.h
@@ -1,22 +1,19 @@
 #ifndef __OPT_ENV_H__
 #define __OPT_ENV_H__
 
-#include "matrix.h"
 #include <iostream>
+#include "matrix.h"
 #include "abstract_env.h"
 #include "abstract_agent.h"
 
 class OptEnv : public AbstractEnv{
-    private:
-        // mat problem_weight;
-        uint m_problem_size;
-
     public:
-        double evaluate(Matrix input_matrix);
-        OptEnv(uint problme_size);
-        ~OptEnv();
-        double evaluate_agent(AbstractAgent &ai);
-
+        explicit OptEnv(uint32_t problem_size);
+        double evaluate_agent(const AbstractAgent &agent, bool verbose=false) const override;
+        const Matrix& get_target_matrix() const { return m_target_matrix; }
+    protected:
+        Matrix m_dummy_state;
+        Matrix m_target_matrix;
 };
 
 #endif

--- a/src/opt_env.h
+++ b/src/opt_env.h
@@ -6,6 +6,10 @@
 #include "abstract_env.h"
 #include "abstract_agent.h"
 
+// The optEnv has a hidden target matrix with shape (1, `problem_size`)
+// The agent guess a matrix and the OptEnv will provide the mean squared error between the guessing and the answer.
+// The agent has to figure out what is the target matrix.
+// OptEnv doesn't nedd an "observation", but we still provide a zero matrix as dummy observation for interface alignment.
 class OptEnv : public AbstractEnv{
     public:
         explicit OptEnv(uint32_t problem_size);

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,0 +1,25 @@
+#ifndef __UTILS_H__
+#define __UTILS_H__
+
+#include <cstdlib>
+#include <iostream>
+#include <ctime>
+#include <armadillo>
+
+namespace utils{
+
+void init_random_seed(unsigned seed)
+{
+    arma::arma_rng::set_seed(seed);
+    std::srand(seed);
+}
+
+void init_random_seed()
+{
+    arma::arma_rng::set_seed_random();
+    std::srand(std::time(0));
+}
+
+}
+
+#endif

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,6 +1,7 @@
 #ifndef __UTILS_H__
 #define __UTILS_H__
 
+#include <sys/time.h>
 #include <cstdlib>
 #include <iostream>
 #include <ctime>
@@ -8,18 +9,25 @@
 
 namespace utils{
 
-void init_random_seed(unsigned seed)
+inline void init_random_seed(unsigned seed)
 {
     arma::arma_rng::set_seed(seed);
     std::srand(seed);
 }
 
-void init_random_seed()
+inline void init_random_seed()
 {
     arma::arma_rng::set_seed_random();
     std::srand(std::time(0));
 }
 
+inline double get_current_time_in_seconds()
+{
+    static const int MILLI_SECONDS = 1e6;
+    struct timeval now_time;
+    gettimeofday(&now_time, NULL);
+    return now_time.tv_sec + (1.0/MILLI_SECONDS) * now_time.tv_usec;
 }
 
+}
 #endif


### PR DESCRIPTION
1. `AbstrctEnv` can simulate several games independently. Do not require copy anymore.
2. Fix bug in `Game2048Env` that cause action 0 never be chosen.
3. Trim `AbstractEnv` for simplicity. `evaluate_agent()` become a pure virtual function.
4. Add `const` specifier to several member functions.
5. Remove `state` from src/2048_board.h because it is useless.
6. Add `FitEnv` for function fitting task.
7. Add functions in src/utils.h to init random seed and to query current time.
8. Add comments for each environment
1. Rewrite `OptEnv`, and its goal is to find the global minimum of a function.
2. Collect math functions into a separate file. `OptEnv` and `FitEnv` will share it.
3. `DnnAgent` can support bias adding for arbitrary batch size.