### PR TITLE
Fix poor efficiency due to rand()'s race condition in multi-threading

### DIFF
--- a/src/2048_board.h
+++ b/src/2048_board.h
@@ -24,6 +24,7 @@
 #include <cmath>
 #include <fstream>
 #include "matrix.h"
+#include "rand_num_generator.h"
 
 /**
 * The simplest bitboard implementation for 2048 board
@@ -46,8 +47,8 @@ class board {
 public:
     typedef unsigned long long value_t;
 
-    inline board(const value_t& raw = 0) : raw(raw) {}
-    inline board(const board& b) : raw(b.raw) {}
+    inline board(const value_t& raw = 0) : raw(raw), m_rand_num_generator() {}
+    inline board(const board& b) : raw(b.raw), m_rand_num_generator() {}
     inline operator value_t&() { return raw; }
 
     inline int  fetch(const int& i) const { return ((raw >> (i << 4)) & 0xffff); }          // fetch row
@@ -209,7 +210,7 @@ public:
                 space[num++] = i;
             }
         if (num)
-            set(space[rand() % num], rand() % 10 ? 1 : 2);
+            set(space[m_rand_num_generator.get_number() % num], m_rand_num_generator.get_number() % 10 ? 1 : 2);
     }
 
     friend std::ostream& operator <<(std::ostream& out, const board& b) {
@@ -238,6 +239,7 @@ public:
 
 private:
     value_t raw;
+    RandNumGenerator m_rand_num_generator;
 };
 
 typedef board Board2048;

--- a/src/rand_num_generator.h
+++ b/src/rand_num_generator.h
@@ -1,0 +1,34 @@
+#ifndef __RANDOM_NUMBER_GENERATOR_H__
+
+#include<chrono>
+#include<iostream>
+// reference: https://en.wikipedia.org/wiki/Xorshift#xorshift*
+class RandNumGenerator
+{
+public:
+    RandNumGenerator()
+    :m_seed(std::chrono::system_clock::now().time_since_epoch().count())
+    {
+
+    }
+
+    RandNumGenerator(uint64_t seed)
+    :m_seed(seed)
+    {
+        if (seed == 0){
+            std::cerr << __FILE__ << ":" << __LINE__<< ": Seed cannot be zero! Automatically pick another seed.\n";
+            m_seed = std::chrono::system_clock::now().time_since_epoch().count();
+        }
+    }
+
+    uint64_t get_number() {
+        m_seed ^= m_seed >> 12;
+        m_seed ^= m_seed << 25;
+        m_seed ^= m_seed >> 27;
+        return m_seed * 0x2545F4914F6CDD1D;
+    }
+protected:
+    uint64_t m_seed = 19940901;
+};
+
+#endif


### PR DESCRIPTION
1. Fix poor efficiency due to rand()'s race condition in multi-threading.
2. Implement a random number generator based on **Xorshift** algorithm. [reference](https://en.wikipedia.org/wiki/Xorshift#xorshift*)

### Execution Time Comparison 
Tested on a 2 CPU (hyper 4 thread) machine

Threads | rand() | Xorshift
:---: | ---: | ---:
1 | 1.384s | 1.069s
2 | 7.040s | 0.545s
4 | 4.019s | 0.419s

### Initial State Distribution
x-axis is the state rank, y-axis is the ratio of that state. The area under curve sum up to one.

![image](https://user-images.githubusercontent.com/6024634/33527464-7bdff466-d88c-11e7-9b8d-aa3f652c32dc.png)

### Random Play Final State Distribution
x-axis is the rank, y-axis is the ratio of that state. The area under curve sum up to one.

![image](https://user-images.githubusercontent.com/6024634/33527875-02c185c0-d893-11e7-9af4-7de92f3ac4db.png)

### Most Frequent Endgame 
**rand()** and **Xorshift** lead to the same result

4 | 32 | 64 | 128
---|---|---|---
8 | 16 | 32 | 64
4 | 8 | 16 | 32
2 |  4 | 8 | 16