### PR TITLE
Fix slow execution bug

### DIFF
--- a/src/weight.h
+++ b/src/weight.h
@@ -23,7 +23,7 @@ public:
     inline const uint get_count() const { return m_weights_vector.size(); }
     //inline void set_weights_vector(const Weights& weights) { m_weights_vector = weights.m_weights_vector;}
     inline Matrix &operator[] (const int x) { return m_weights_vector[x]; }
-    inline const Matrix operator[] (const int x) const { return m_weights_vector[x]; }
+    inline const Matrix &operator[] (const int x) const { return m_weights_vector[x]; }
     Weights& operator=(const Weights weight);
     Weights& operator*=(const double scalar);
     Weights& operator+=(const Weights weight);


### PR DESCRIPTION
#### Description
After commit [1eb5a...](https://github.com/C14016112/project_atum/commit/1eb5ace68c94afa43c15a5afd56f8793be4e29c8), the execution time increase a lot. 

#### Cause
`Weight` doesn't return a **reference** when calling constant `[]` operator.
In `weight.h` [line 26](https://github.com/C14016112/project_atum/blob/master/src/weight.h#L26),  `inline const Matrix operator[] {...}` should be  `inline const Matrix &operator[]
{...}`
#### Before Bug Fix
```
$ time taskset -c 3  ./train | tee time_slow.log
thread_number: 1
max_iteration: 50
population: 100
is load model: 0
model: 16 64 64 64 1 
es sigma: 0.1
es alpha: 0.01
thread number: 1
cur_iteration 0, time: 0.653862, average reward 878.04
cur_iteration 10, time: 6.05709, average reward 1004.74
cur_iteration 20, time: 11.7375, average reward 1127.54
cur_iteration 30, time: 18.0314, average reward 1365.84
cur_iteration 40, time: 25.7872, average reward 1812.3

real    0m34.111s
user    0m33.628s
sys     0m0.104s
```
#### After Bug Fix
```
$ time taskset -c 3  ./train | tee time_slow.log
thread_number: 1
max_iteration: 50
population: 100
is load model: 0
model: 16 64 64 64 1 
es sigma: 0.1
es alpha: 0.01
thread number: 1
cur_iteration 0, time: 0.447668, average reward 1032.64
cur_iteration 10, time: 3.69123, average reward 1064.4
cur_iteration 20, time: 6.98887, average reward 1101.58
cur_iteration 30, time: 10.5861, average reward 1428.22
cur_iteration 40, time: 14.409, average reward 1497.02

real    0m18.100s
user    0m17.952s
sys     0m0.084s
```